### PR TITLE
fix: add some crucial connection options for MYSSQL Server connection type

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,7 @@ jobs:
   AutogenerateTerraformRepoDocs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
+        persist-credentials: false
+        fetch-depth: 0
 
     - name: Render terraform docs and push changes back to PR
       uses: terraform-docs/gh-actions@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ module "databricks_lakehouse_federation" {
       host     = data.azurerm_mssql_server.example.fqdn
       user     = "mssql-admin-username"
       password = "mssql-example-password"
+      application_intent  = "ReadOnly"  # Optional. Or other intent like ReadWrite
+      trustServerCertificate = "true"   # Optional. Or "false" depending on your requirements
     }
   }
   


### PR DESCRIPTION
### Motivation

After creation a new Databricks connection with MYSQL Server type w/o these undocumented options like:
-  application_intent = "ReadOnly" # or other intent like ReadWrite
-  trustServerCertificate = "true"
this connection is doesn't work. You need to pass these two parameters manually by Databricks UI

### Screenshots

![image](https://github.com/user-attachments/assets/2e00fd79-4c0f-4167-b41e-284303741e4c)
